### PR TITLE
Change test post status codes to 201

### DIFF
--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -81,7 +81,7 @@ def jsonapi_headers_app(app: Starlette):
 
         async def post(self, *args, **kwargs) -> Response:
             await self.validate_body()
-            return Response(status_code=200)
+            return Response(status_code=201)
 
         async def patch(self, id=None, *args, **kwargs) -> Response:
             await self.validate_body()
@@ -499,7 +499,7 @@ def test_method_not_allowed(app: Starlette):
             return Response(status_code=200)
 
         async def post(self, *args, **kwargs) -> Response:
-            return Response(status_code=200)
+            return Response(status_code=201)
 
     TResource.register_routes(app, '/')
 


### PR DESCRIPTION
This has no affect on the tests
Mainly for the reader to set the example that according to JSON:API posts should return 201