### PR TITLE
Be more specific why the body content could not be read

### DIFF
--- a/starlette_jsonapi/resource.py
+++ b/starlette_jsonapi/resource.py
@@ -101,7 +101,7 @@ class BaseResource:
             body = await self.request.json()
         except Exception:
             logger.debug('Could not read request body.', exc_info=True)
-            raise JSONAPIException(status_code=400, detail='Could not read request body.')
+            raise JSONAPIException(status_code=400, detail='Could not read request body as JSON.')
 
         errors = self.schema(app=self.request.app).validate(body, partial=partial)
         if errors:

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -263,7 +263,7 @@ def test_deserialize_raises_validation_errors(serialization_app: Starlette):
     assert rv.json() == {
         'errors': [
             {
-                'detail': 'Could not read request body.',
+                'detail': 'Could not read request body as JSON.',
             }
         ]
     }


### PR DESCRIPTION
As I read through things, I wondered why the body could not be read. Was it because I put something in the wrong place, did I encode things wrongly. I thought that saying it could not be read as JSON would help the user know that the body must be json