### PR TITLE
Top level meta

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ Since this project is under development, please pin your dependencies to avoid p
 - relationship resources
 - sparse fields
 - support for client generated IDS
+- support top level meta objects
 
 ### Todo:
 - [pagination helpers](https://jsonapi.org/format/#fetching-pagination)
 - [sorting helpers](https://jsonapi.org/format/#fetching-sorting)
 - documentation
 - examples for other ORMs
-- [support meta objects](https://jsonapi.org/format/#document-meta)
 - [support jsonapi objects](https://jsonapi.org/format/#document-jsonapi-object)
 - [enforce member name validation](https://jsonapi.org/format/#document-member-names)
 - [optionally enforce query name validation](https://jsonapi.org/format/#query-parameters)
@@ -327,6 +327,13 @@ mentions:
 
 If you intend to use `uuid` IDs, set `id_mask = 'uuid'` when defining the Resource class, and some validation
 will be handled by Starlette. Requests with malformed IDS will likely result in 404 errors. 
+
+### Top level meta objects
+To include a `meta` object ([specification](https://jsonapi.org/format/#document-meta)) in the top level
+json:api response, you can pass a dictionary `meta` argument when calling `to_response`,
+in a primary or relationship resource:
+
+```to_response({'id': 123, ....}, meta={'copyright': 'FooBar'})```
 
 ## Contributing
 This project is in its early days, so **any** help is appreciated.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Since this project is under development, please pin your dependencies to avoid p
 - exception handlers to serialize as json:api responses
 - relationship resources
 - sparse fields
-- support for client generated IDS
+- support for client generated IDs
 - support top level meta objects
 
 ### Todo:

--- a/starlette_jsonapi/resource.py
+++ b/starlette_jsonapi/resource.py
@@ -441,11 +441,15 @@ class BaseRelationshipResource:
         body = relationship.serialize(self.relationship_name, data)
         return body
 
-    async def to_response(self, data: dict, *args, **kwargs) -> JSONAPIResponse:
+    async def to_response(self, data: dict, meta: dict = None, *args, **kwargs) -> JSONAPIResponse:
         """
         Wraps `data` in a JSONAPIResponse object and returns it.
+        If `meta` is specified, it will be included as the top level `meta` object in the json:api response.
         Additional args and kwargs are passed to the `starlette` based Response.
         """
+        if meta:
+            data = data.copy()
+            data.update(meta=meta)
         return JSONAPIResponse(
             content=data,
             *args, **kwargs,

--- a/starlette_jsonapi/resource.py
+++ b/starlette_jsonapi/resource.py
@@ -174,11 +174,15 @@ class BaseResource(metaclass=RegisteredResourceMeta):
         sparse_body = await self.process_sparse_fields(body, many=many)
         return sparse_body
 
-    async def to_response(self, data: dict, *args, **kwargs) -> JSONAPIResponse:
+    async def to_response(self, data: dict, meta: dict = None, *args, **kwargs) -> JSONAPIResponse:
         """
         Wraps `data` in a JSONAPIResponse object and returns it.
+        If `meta` is specified, it will be included as the top level `meta` object in the json:api response.
         Additional args and kwargs are passed to the `starlette` based Response.
         """
+        if meta:
+            data = data.copy()
+            data.update(meta=meta)
         return JSONAPIResponse(
             content=data,
             *args, **kwargs,


### PR DESCRIPTION
Adds possibility to include top level `meta` objects in the json:api response.

`to_response` signature changed to `async def to_response(self, data: dict, meta: dict = None, *args, **kwargs) -> JSONAPIResponse`