### PR TITLE
Move handler execution into a separate class method

### DIFF
--- a/starlette_jsonapi/resource.py
+++ b/starlette_jsonapi/resource.py
@@ -135,9 +135,7 @@ class _BaseResourceHandler:
             try:
                 if request.method not in cls.allowed_methods:
                     raise JSONAPIException(status_code=405)
-                resource = cls(request, request_context, *args, **kwargs)
-                handler = getattr(resource, handler_name, None)
-                response = await handler(*args, **kwargs)
+                response = await cls.execute_handler(request, request_context, handler_name, *args, **kwargs)
             except Exception as e:
                 response = await cls.handle_error(request, request_context, exc=e)
 
@@ -148,7 +146,24 @@ class _BaseResourceHandler:
                 response = await cls.handle_error(request, request_context, exc=after_request_exc)
 
         return response
+    
+    @classmethod
+    async def execute_handler(
+        cls, request: Request, request_context: dict, handler_name: str,
+        *args, **kwargs
+    ) -> Response:
+        """
+        Finds a handler on this resource given its name and calls it.
 
+        :param request: current HTTP request
+        :param request_context: current request context
+        :param handler_name: name of the handler callable
+        """
+        resource = cls(request, request_context, *args, **kwargs)
+        handler = getattr(resource, handler_name, None)
+        response = await handler(*args, **kwargs)
+        return response
+        
     def process_sparse_fields_request(self, serialized_data: dict, many: bool = False) -> dict:
         """
         Processes sparse fields requests by calling


### PR DESCRIPTION
The change allows consumers of the library to modify exactly how handler resource methods are called. My case is dependency injection (with [lagom](https://github.com/meadsteve/lagom)):

```Python3
class ResourceWithDependencyInjection(Resource):
    dependency_container: Container

    @classmethod
    async def execute_handler(cls, request, request_context, handler_name, *args, **kwargs):
        resource = cls(request, request_context, *args, **kwargs)
        handler = getattr(resource, handler_name, None)
        handler_with_deps = cls.dependency_container.partial(handler)
        response = await handler_with_deps(*args, **kwargs)
        return response

    @classmethod
    def register_routes(cls, app, base_path: str = '', container: Container = Container()):
        cls.dependency_container = container
        super().register_routes(app, base_path)
```

Regardless, it's a nice refactor in the spirit of SRP.