### PR TITLE
bugfix/keyerror-at-fields-to-jsonapi-schema-rendering

### DIFF
--- a/starlette_jsonapi/openapi.py
+++ b/starlette_jsonapi/openapi.py
@@ -106,7 +106,7 @@ class JSONAPISchemaConverter(OpenAPIConverter):
                 properties['attributes']['properties'][observed_field_name] = prop
             # TODO: support meta fields
 
-            if field_obj.required:
+            if field_obj.required and field_name != 'id':
                 if not partial or (
                     is_collection(partial) and field_name not in partial
                 ):


### PR DESCRIPTION
The implementations out for review are used to fix KeyError happening at fields to JSON:API schema rendering due to failing logic applied due iteration. See related issue @ https://github.com/vladmunteanu/starlette-jsonapi/issues/45.